### PR TITLE
feat(users): add user with scaffold and has a self join model

### DIFF
--- a/test-app/app/assets/stylesheets/users.scss
+++ b/test-app/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/test-app/app/controllers/users_controller.rb
+++ b/test-app/app/controllers/users_controller.rb
@@ -1,0 +1,69 @@
+class UsersController < ApplicationController
+  before_action :set_user, only: %i[ show edit update destroy ]
+
+  # GET /users or /users.json
+  def index
+    @users = User.all
+  end
+
+  # GET /users/1 or /users/1.json
+  def show
+  end
+
+  # GET /users/new
+  def new
+    @user = User.new
+  end
+
+  # GET /users/1/edit
+  def edit
+  end
+
+  # POST /users or /users.json
+  def create
+    @user = User.new(user_params)
+
+    respond_to do |format|
+      if @user.save
+        format.html { redirect_to @user, notice: "User was successfully created." }
+        format.json { render :show, status: :created, location: @user }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @user.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /users/1 or /users/1.json
+  def update
+    respond_to do |format|
+      if @user.update(user_params)
+        format.html { redirect_to @user, notice: "User was successfully updated." }
+        format.json { render :show, status: :ok, location: @user }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @user.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /users/1 or /users/1.json
+  def destroy
+    @user.destroy
+    respond_to do |format|
+      format.html { redirect_to users_url, notice: "User was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_user
+      @user = User.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def user_params
+      params.require(:user).permit(:name)
+    end
+end

--- a/test-app/app/helpers/users_helper.rb
+++ b/test-app/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/test-app/app/models/article.rb
+++ b/test-app/app/models/article.rb
@@ -1,2 +1,3 @@
 class Article < ApplicationRecord
+  belongs_to :user
 end

--- a/test-app/app/models/user.rb
+++ b/test-app/app/models/user.rb
@@ -1,0 +1,7 @@
+class User < ApplicationRecord
+  has_one :article
+  belongs_to :mother, class_name: "User", optional: true
+  belongs_to :father, class_name: "User", optional: true
+  has_one :grandfather, through: :father, source: :father
+  has_one :grandmother, through: :father, source: :mother
+end

--- a/test-app/app/views/users/_form.html.erb
+++ b/test-app/app/views/users/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(model: user) do |form| %>
+  <% if user.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(user.errors.count, "error") %> prohibited this user from being saved:</h2>
+
+      <ul>
+        <% user.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :name %>
+    <%= form.text_field :name %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/test-app/app/views/users/_user.json.jbuilder
+++ b/test-app/app/views/users/_user.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! user, :id, :name, :created_at, :updated_at
+json.url user_url(user, format: :json)

--- a/test-app/app/views/users/edit.html.erb
+++ b/test-app/app/views/users/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing User</h1>
+
+<%= render 'form', user: @user %>
+
+<%= link_to 'Show', @user %> |
+<%= link_to 'Back', users_path %>

--- a/test-app/app/views/users/index.html.erb
+++ b/test-app/app/views/users/index.html.erb
@@ -1,0 +1,27 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Users</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @users.each do |user| %>
+      <tr>
+        <td><%= user.name %></td>
+        <td><%= link_to 'Show', user %></td>
+        <td><%= link_to 'Edit', edit_user_path(user) %></td>
+        <td><%= link_to 'Destroy', user, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New User', new_user_path %>

--- a/test-app/app/views/users/index.json.jbuilder
+++ b/test-app/app/views/users/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @users, partial: "users/user", as: :user

--- a/test-app/app/views/users/new.html.erb
+++ b/test-app/app/views/users/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New User</h1>
+
+<%= render 'form', user: @user %>
+
+<%= link_to 'Back', users_path %>

--- a/test-app/app/views/users/show.html.erb
+++ b/test-app/app/views/users/show.html.erb
@@ -1,0 +1,9 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Name:</strong>
+  <%= @user.name %>
+</p>
+
+<%= link_to 'Edit', edit_user_path(@user) %> |
+<%= link_to 'Back', users_path %>

--- a/test-app/app/views/users/show.json.jbuilder
+++ b/test-app/app/views/users/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "users/user", user: @user

--- a/test-app/config/routes.rb
+++ b/test-app/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :users
   resources :articles
   root 'pages#home'
   # get request to the abouts page. To: controller#action

--- a/test-app/db/migrate/20210701100245_create_users.rb
+++ b/test-app/db/migrate/20210701100245_create_users.rb
@@ -1,0 +1,7 @@
+class CreateUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :users do |t|
+      t.string :name
+    end
+  end
+end

--- a/test-app/db/migrate/20210701100245_create_users.rb
+++ b/test-app/db/migrate/20210701100245_create_users.rb
@@ -2,6 +2,8 @@ class CreateUsers < ActiveRecord::Migration[6.1]
   def change
     create_table :users do |t|
       t.string :name
+      t.references :mother
+      t.references :father
     end
   end
 end

--- a/test-app/db/migrate/20210703133125_add_user_id_to_articles.rb
+++ b/test-app/db/migrate/20210703133125_add_user_id_to_articles.rb
@@ -1,0 +1,6 @@
+class AddUserIdToArticles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :articles, :user_id, :int
+  end
+end
+

--- a/test-app/db/migrate/20210705123948_add_mother_id_to_users.rb
+++ b/test-app/db/migrate/20210705123948_add_mother_id_to_users.rb
@@ -1,5 +1,0 @@
-class AddMotherIdToUsers < ActiveRecord::Migration[6.1]
-  def change
-      add_column :users, :mother_id, :int
-  end
-end

--- a/test-app/db/migrate/20210705123948_add_mother_id_to_users.rb
+++ b/test-app/db/migrate/20210705123948_add_mother_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddMotherIdToUsers < ActiveRecord::Migration[6.1]
+  def change
+      add_column :users, :mother_id, :int
+  end
+end

--- a/test-app/db/migrate/20210705123955_add_father_id_to_users.rb
+++ b/test-app/db/migrate/20210705123955_add_father_id_to_users.rb
@@ -1,5 +1,0 @@
-class AddFatherIdToUsers < ActiveRecord::Migration[6.1]
-  def change
-    add_column :users, :father_id, :int
-  end
-end

--- a/test-app/db/migrate/20210705123955_add_father_id_to_users.rb
+++ b/test-app/db/migrate/20210705123955_add_father_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddFatherIdToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :father_id, :int
+  end
+end

--- a/test-app/db/schema.rb
+++ b/test-app/db/schema.rb
@@ -10,13 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_24_123207) do
+ActiveRecord::Schema.define(version: 2021_07_05_123955) do
 
   create_table "articles", force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name"
+    t.integer "mother_id"
+    t.integer "father_id"
   end
 
 end

--- a/test-app/db/schema.rb
+++ b/test-app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_05_123955) do
+ActiveRecord::Schema.define(version: 2021_07_03_133125) do
 
   create_table "articles", force: :cascade do |t|
     t.string "title"
@@ -24,6 +24,8 @@ ActiveRecord::Schema.define(version: 2021_07_05_123955) do
     t.string "name"
     t.integer "mother_id"
     t.integer "father_id"
+    t.index ["father_id"], name: "index_users_on_father_id"
+    t.index ["mother_id"], name: "index_users_on_mother_id"
   end
 
 end

--- a/test-app/test/controllers/users_controller_test.rb
+++ b/test-app/test/controllers/users_controller_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+  end
+
+  test "should get index" do
+    get users_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_user_url
+    assert_response :success
+  end
+
+  test "should create user" do
+    assert_difference('User.count') do
+      post users_url, params: { user: { name: @user.name } }
+    end
+
+    assert_redirected_to user_url(User.last)
+  end
+
+  test "should show user" do
+    get user_url(@user)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_user_url(@user)
+    assert_response :success
+  end
+
+  test "should update user" do
+    patch user_url(@user), params: { user: { name: @user.name } }
+    assert_redirected_to user_url(@user)
+  end
+
+  test "should destroy user" do
+    assert_difference('User.count', -1) do
+      delete user_url(@user)
+    end
+
+    assert_redirected_to users_url
+  end
+end

--- a/test-app/test/fixtures/users.yml
+++ b/test-app/test/fixtures/users.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test-app/test/models/user_test.rb
+++ b/test-app/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test-app/test/system/users_test.rb
+++ b/test-app/test/system/users_test.rb
@@ -1,0 +1,43 @@
+require "application_system_test_case"
+
+class UsersTest < ApplicationSystemTestCase
+  setup do
+    @user = users(:one)
+  end
+
+  test "visiting the index" do
+    visit users_url
+    assert_selector "h1", text: "Users"
+  end
+
+  test "creating a User" do
+    visit users_url
+    click_on "New User"
+
+    fill_in "Name", with: @user.name
+    click_on "Create User"
+
+    assert_text "User was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a User" do
+    visit users_url
+    click_on "Edit", match: :first
+
+    fill_in "Name", with: @user.name
+    click_on "Update User"
+
+    assert_text "User was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a User" do
+    visit users_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "User was successfully destroyed"
+  end
+end


### PR DESCRIPTION
`User.rb` model
```ruby
class User < ApplicationRecord
  belongs_to :mother, class_name: "User", optional: true
  belongs_to :father, class_name: "User", optional: true
  has_one :grandfather, through: :father, source: :father
  has_one :grandmother, through: :father, source: :mother
end
```

1. `belongs_to :mother, class_name: "User", optional: true` and `belongs_to :father, class_name: "User", optional: true`
    1. `belongs_to` will create a foreign_key in the User model called as `mother_id` and `father_id1 respectively
    1. The purpose of `:class_name` is to allow me to use a class that is different from the one Rails expects. When I have a `belongs_to :mother` or `belongs_to :father` in the model, Rails would expect that to point to a parent class called `Mother` or `Father`. But my code tells Rails to skip looking for a `Mother`  or `Father` class and instead look to the User model.
    1. `optional: true` allows the `mother_id` and `father_id` column to be `nil`

1.  `  has_one :grandfather, through: :father, source: :father` and `has_one :grandmother, through: :father, source: :mother`
    1. The `has_one :through` association  helps set up a one-to-one association with a third model (grandfather/grandmother) by going through a second model (father).
    1. `:source` option specifies the source association name for the `has_one :through` association. I am renaming the father and mother association to father. If I don't provide the `:source`, Rails will look for an association called grandfather/grandmother in the Father(User) class. I have to tell it to use the father/mother association in the Father(User) class in order to get the right object.

My final table created with the data:
![image](https://user-images.githubusercontent.com/67599130/124756828-7dc6cd80-df5f-11eb-889d-c740a46d48aa.png)

